### PR TITLE
Release new Patch on crates.io with InputPin Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,5 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/japaric/linux-embedded-hal/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/japaric/linux-embedded-hal/compare/v0.2.1...HEAD
+[v0.2.1]: https://github.com/rust-embedded/linux-embedded-hal/compare/v0.2.0...v0.2.1
+[v0.2.0]: https://github.com/rust-embedded/linux-embedded-hal/compare/v0.1.1...v0.2.0
 [v0.1.1]: https://github.com/japaric/linux-embedded-hal/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.2.1] - 2018-10-25
+
+### Added
+
+- implementation of the unproven `embedded_hal::::digital::InputPin` trait. 
+
 ## [v0.2.0] - 2018-05-14
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["Linux", "hal"]
 license = "MIT OR Apache-2.0"
 name = "linux-embedded-hal"
 repository = "https://github.com/japaric/linux-embedded-hal"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 embedded-hal = { version = "0.2.0", features = ["unproven"] }


### PR DESCRIPTION
Since #9 still seems to be WIP a small update for crates.io would be nice, so I could move back to the crates.io version of this package.