### PR TITLE
Bump i2cdev version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.2.1"
 
 [dependencies]
 embedded-hal = { version = "0.2.0", features = ["unproven"] }
-i2cdev = "0.3.1"
+i2cdev = "0.4.1"
 spidev = "0.3.0"
 sysfs_gpio = "0.5.1"
 


### PR DESCRIPTION
rust-i2cdev has a new minor version that removes a pile of dependencies (and speeds up builds measurably), see: https://github.com/rust-embedded/rust-i2cdev/pull/47

This PR bumps i2cdev to the updated version and adds a missing newline to the end of cargo.toml