### PR TITLE
Release new patch on crates.io with minimised i2c dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.2.2] - 2018-12-21
+
+### Changed
+
+- updated to i2cdev 0.4.1 (removes superflous dependencies)
+
 ## [v0.2.1] - 2018-10-25
 
 ### Added
@@ -33,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Initial release
 
 [Unreleased]: https://github.com/japaric/linux-embedded-hal/compare/v0.2.1...HEAD
+[v0.2.2]: https://github.com/japaric/linux-embedded-hal/compare/v0.2.1...v0.2.2
 [v0.2.1]: https://github.com/rust-embedded/linux-embedded-hal/compare/v0.2.0...v0.2.1
 [v0.2.0]: https://github.com/rust-embedded/linux-embedded-hal/compare/v0.1.1...v0.2.0
 [v0.1.1]: https://github.com/japaric/linux-embedded-hal/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["Linux", "hal"]
 license = "MIT OR Apache-2.0"
 name = "linux-embedded-hal"
 repository = "https://github.com/japaric/linux-embedded-hal"
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 embedded-hal = { version = "0.2.0", features = ["unproven"] }


### PR DESCRIPTION
Following #14 this release contains a newer version of the i2cdev crate that decreases the number of dependencies and thus build time (measured on an rpi3 from 1hr 20 mins to 20 mins).