### PR TITLE
Remove #[deny(warnings)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@
 //! [0]: https://crates.io/keywords/embedded-hal
 
 #![deny(missing_docs)]
-#![deny(warnings)]
 
 extern crate cast;
 extern crate embedded_hal as hal;


### PR DESCRIPTION
The library currently does not currently build anymore, because upstream libraries have added new deprecation warnings. A deprecation warning should not break compilation though. There was a post on Reddit about this about a year ago, but I can't find it anymore.

I think adding a CI check step would be fine, but `#[deny(warnings)]` is a bit too much.

These are the warnings:

```
warning: use of deprecated item 'hal::digital::OutputPin': Deprecated because the methods cannot return errors. Users should use the traits in digital::v2.
   --> src/lib.rs:111:6                                                       
    |                                                                         
111 | impl hal::digital::OutputPin for Pin {                                  
    |      ^^^^^^^^^^^^^^^^^^^^^^^                                            
    |                                                                         
    = note: #[warn(deprecated)] on by default                                 
                                                                              
warning: use of deprecated item 'hal::digital::InputPin': Deprecated because the methods cannot return errors. Users should use the traits in digital::v2.
   --> src/lib.rs:121:6                                                       
    |                                                                         
121 | impl hal::digital::InputPin for Pin {                                   
    |      ^^^^^^^^^^^^^^^^^^^^^^                                             
                                                                              
warning: use of deprecated item 'hal::digital::InputPin::is_high': Deprecated because the methods cannot return errors. Users should use the traits in digital::v2.
   --> src/lib.rs:131:15                                                      
    |                                                                         
131 |         !self.is_high()                                                 
    |               ^^^^^^^                                                                                                                             
```