### PR TITLE
Update spidev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ version = "0.2.2"
 
 [dependencies]
 embedded-hal = { version = "0.2.0", features = ["unproven"] }
-i2cdev = "0.4.1"
-spidev = "0.3.0"
-sysfs_gpio = "0.5.1"
+i2cdev = "0.4"
+spidev = "0.4"
+sysfs_gpio = "0.5"
 serial-unix = "0.4.0"
 serial-core = "0.4.0"
 nb = "0.1.1"


### PR DESCRIPTION
Currently dependencies have to be compiled multiple times due to version mismatches. Upgrading to `spidev=0.4` fixes that problem.

Before:
```
├── linux-embedded-hal v0.2.2
│   ├── cast v0.2.2
│   ├── embedded-hal v0.2.3 (*)
│   ├── i2cdev v0.4.2
│   │   ├── bitflags v1.1.0
│   │   ├── byteorder v1.3.2
│   │   ├── libc v0.2.62
│   │   └── nix v0.14.1
│   │       ├── bitflags v1.1.0 (*)
│   │       ├── cfg-if v0.1.9
│   │       ├── libc v0.2.62 (*)
│   │       └── void v1.0.2 (*)
│   ├── spidev v0.3.0
│   │   ├── bitflags v0.3.3
│   │   ├── libc v0.2.62 (*)
│   │   └── nix v0.6.0
│   │       ├── bitflags v0.4.0
│   │       ├── cfg-if v0.1.9 (*)
│   │       ├── libc v0.2.62 (*)
│   │       └── void v1.0.2 (*)
│   │       [build-dependencies]
│   │       ├── rustc_version v0.1.7
│   │       │   └── semver v0.1.20
│   │       └── semver v0.1.20 (*)
│   └── sysfs_gpio v0.5.4
│       └── nix v0.14.1 (*)
```

After:
```
├── linux-embedded-hal v0.2.2
│   ├── cast v0.2.2
│   ├── embedded-hal v0.2.3 (*)
│   ├── i2cdev v0.4.2
│   │   ├── bitflags v1.1.0
│   │   ├── byteorder v1.3.2
│   │   ├── libc v0.2.62
│   │   └── nix v0.14.1
│   │       ├── bitflags v1.1.0 (*)
│   │       ├── cfg-if v0.1.9
│   │       ├── libc v0.2.62 (*)
│   │       └── void v1.0.2 (*)
│   ├── nb v0.1.2 (*)
│   ├── serial-core v0.4.0
│   │   └── libc v0.2.62 (*)
│   ├── serial-unix v0.4.0
│   │   ├── ioctl-rs v0.1.6
│   │   │   └── libc v0.2.62 (*)
│   │   ├── libc v0.2.62 (*)
│   │   ├── serial-core v0.4.0 (*)
│   │   └── termios v0.2.2
│   │       └── libc v0.2.62 (*)
│   ├── spidev v0.4.0
│   │   ├── bitflags v1.1.0 (*)
│   │   ├── libc v0.2.62 (*)
│   │   └── nix v0.14.1 (*)
│   └── sysfs_gpio v0.5.4
│       └── nix v0.14.1 (*)
```