### PR TITLE
Transactional WriteRead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Do write and read in one transaction in WriteRead implementation.
+
+### Changed
+
+- updated to i2cdev 0.4.3 (necessary for trasactional write-read).
+
 ## [v0.2.2] - 2018-12-21
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.2.2"
 
 [dependencies]
 embedded-hal = { version = "0.2.0", features = ["unproven"] }
-i2cdev = "0.4"
+i2cdev = "0.4.3"
 spidev = "0.4"
 sysfs_gpio = "0.5"
 serial-unix = "0.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,8 @@ use std::time::Duration;
 use std::{ops, thread};
 
 use cast::{u32, u64};
-use i2cdev::core::I2CDevice;
+use i2cdev::core::{I2CDevice, I2CMessage, I2CTransfer};
+use i2cdev::linux::LinuxI2CMessage;
 use spidev::SpidevTransfer;
 
 mod serial;
@@ -219,8 +220,11 @@ impl hal::blocking::i2c::WriteRead for I2cdev {
         buffer: &mut [u8],
     ) -> Result<(), Self::Error> {
         self.set_address(address)?;
-        self.inner.write(bytes)?;
-        self.inner.read(buffer)
+        let mut messages = [
+            LinuxI2CMessage::write(bytes),
+            LinuxI2CMessage::read(buffer),
+        ];
+        self.inner.transfer(&mut messages).map(drop)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ impl I2cdev {
 
     fn set_address(&mut self, address: u8) -> Result<(), i2cdev::linux::LinuxI2CError> {
         if self.address != Some(address) {
-            self.inner = i2cdev::linux::LinuxI2CDevice::new(&self.path, address as u16)?;
+            self.inner = i2cdev::linux::LinuxI2CDevice::new(&self.path, u16::from(address))?;
             self.address = Some(address);
         }
         Ok(())


### PR DESCRIPTION
This fixes #25 by implementing a transactional write-read without STOP in the middle.
It also fixes a type cast which was the only warning present.