### PR TITLE
Release 0.3.0 preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.3.0] - 2019-11-25
+
+### Added
+
+- Added serial::Read/Write implementation.
+
 ### Fixed
 
 - Do write and read in one transaction in WriteRead implementation.
+- Removed #[deny(warnings)]
 
 ### Changed
 
-- updated to i2cdev 0.4.3 (necessary for trasactional write-read).
+- Use embedded-hal::digital::v2 traits.
+- Updated to i2cdev 0.4.3 (necessary for trasactional write-read).
+- Updated to spidev 0.4
 
 ## [v0.2.2] - 2018-12-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Do write and read in one transaction in WriteRead implementation.
+
+### Changed
+
+- updated to i2cdev 0.4.3 (necessary for trasactional write-read).
+
 ## [v0.2.2] - 2018-12-21
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ keywords = ["Linux", "hal"]
 license = "MIT OR Apache-2.0"
 name = "linux-embedded-hal"
 repository = "https://github.com/japaric/linux-embedded-hal"
-version = "0.2.2"
+version = "0.3.0"
 
 [dependencies]
-embedded-hal = { version = "0.2.0", features = ["unproven"] }
+embedded-hal = { version = "0.2.3", features = ["unproven"] }
 i2cdev = "0.4.3"
 spidev = "0.4"
 sysfs_gpio = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.2.2"
 
 [dependencies]
 embedded-hal = { version = "0.2.0", features = ["unproven"] }
-i2cdev = "0.4"
+i2cdev = "0.4.3"
 spidev = "0.4"
 sysfs_gpio = "0.5"
 serial-unix = "0.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,8 @@ use std::time::Duration;
 use std::{ops, thread};
 
 use cast::{u32, u64};
-use i2cdev::core::I2CDevice;
+use i2cdev::core::{I2CDevice, I2CMessage, I2CTransfer};
+use i2cdev::linux::LinuxI2CMessage;
 use spidev::SpidevTransfer;
 
 mod serial;
@@ -219,8 +220,11 @@ impl hal::blocking::i2c::WriteRead for I2cdev {
         buffer: &mut [u8],
     ) -> Result<(), Self::Error> {
         self.set_address(address)?;
-        self.inner.write(bytes)?;
-        self.inner.read(buffer)
+        let mut messages = [
+            LinuxI2CMessage::write(bytes),
+            LinuxI2CMessage::read(buffer),
+        ];
+        self.inner.transfer(&mut messages).map(drop)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ impl I2cdev {
 
     fn set_address(&mut self, address: u8) -> Result<(), i2cdev::linux::LinuxI2CError> {
         if self.address != Some(address) {
-            self.inner = i2cdev::linux::LinuxI2CDevice::new(&self.path, address as u16)?;
+            self.inner = i2cdev::linux::LinuxI2CDevice::new(&self.path, u16::from(address))?;
             self.address = Some(address);
         }
         Ok(())


### PR DESCRIPTION
I updated the changelog with everything that happened since the 0.2.2 release and bumped the minor version because of the digital::v2.
I also fixed setting the embedded-hal version to 0.2.3 because that is when the digital::v2 traits were released.
This branch sits on top of #26 with the hopeful date of today :)