### PR TITLE
Gpio cdev feature 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,20 @@ name = "linux-embedded-hal"
 repository = "https://github.com/japaric/linux-embedded-hal"
 version = "0.3.0"
 
+[features]
+default = ["sysfs_gpio"]
+
+gpio_cdev = ["gpio-cdev"]
+
 [dependencies]
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
 i2cdev = "0.4.3"
 spidev = "0.4"
-sysfs_gpio = "0.5"
 serial-unix = "0.4.0"
 serial-core = "0.4.0"
 nb = "0.1.1"
+sysfs_gpio = { version = "0.5", optional = true }
+gpio-cdev = { version="0.2", optional = true }
 
 [dev-dependencies]
 openpty = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ This project is developed and maintained by the [Embedded Linux team][team].
 
 ## [Documentation](https://docs.rs/linux-embedded-hal)
 
+## GPIO character device
+
+Since Linux kernel v4.4 the use of sysfs GPIO was deprecated and replaced by the character device GPIO.
+See [gpio-cdev documentation](https://github.com/rust-embedded/gpio-cdev#sysfs-gpio-vs-gpio-character-device) for details.
+
+This crate includes feature flag `gpio_cdev` that replaces [sysfs_gpio](https://crates.io/crates/sysfs_gpio) by [gpio-cdev](https://crates.io/crates/gpio-cdev).
+To enable it update your Cargo.toml. 
+```
+linux-embedded-hal = { version = "0.3", features = ["gpio_cdev"] }
+``` 
+
 ## License
 
 Licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 //! [0]: https://crates.io/keywords/embedded-hal
 
 #![deny(missing_docs)]
+#![feature(doc_cfg)]
 
 extern crate cast;
 extern crate embedded_hal as hal;
@@ -99,9 +100,11 @@ impl hal::blocking::delay::DelayMs<u64> for Delay {
 ///
 /// [`gpio_cdev::LineHandle`]: https://docs.rs/gpio-cdev/0.2.0/gpio_cdev/struct.LineHandle.html
 #[cfg(feature = "gpio_cdev")]
+#[doc(cfg(feature = "gpio_cdev"))]
 pub struct Pin(pub gpio_cdev::LineHandle, bool);
 
 #[cfg(feature = "gpio_cdev")]
+#[doc(cfg(feature = "gpio_cdev"))]
 impl Pin {
     /// See [`gpio_cdev::Line::request`][0] for details.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,11 @@
 extern crate cast;
 extern crate embedded_hal as hal;
 pub extern crate i2cdev;
+pub extern crate nb;
+pub extern crate serial_core;
+pub extern crate serial_unix;
 pub extern crate spidev;
 pub extern crate sysfs_gpio;
-pub extern crate serial_unix;
-pub extern crate serial_core;
-pub extern crate nb;
 
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -220,10 +220,7 @@ impl hal::blocking::i2c::WriteRead for I2cdev {
         buffer: &mut [u8],
     ) -> Result<(), Self::Error> {
         self.set_address(address)?;
-        let mut messages = [
-            LinuxI2CMessage::write(bytes),
-            LinuxI2CMessage::read(buffer),
-        ];
+        let mut messages = [LinuxI2CMessage::write(bytes), LinuxI2CMessage::read(buffer)];
         self.inner.transfer(&mut messages).map(drop)
     }
 }


### PR DESCRIPTION
As requested in #20. This PR adds support for feature that will replace sysfs gpio with cdev gpio. 

Default feature set is still the same so it won't broke any existing code. 