### PR TITLE
Updated logic around sysfs/cdev pin selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Set default features to build both sysfs and cdev pin types
+- Removed `Pin` export, use `CdevPin` or `SysfsPin`
+
 ## [v0.3.0] - 2019-11-25
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,10 @@ repository = "https://github.com/japaric/linux-embedded-hal"
 version = "0.3.0"
 
 [features]
-default = []
 gpio_sysfs = ["sysfs_gpio"]
 gpio_cdev = ["gpio-cdev"]
+
+default = [ "gpio_cdev", "gpio_sysfs" ]
 
 [dependencies]
 embedded-hal = { version = "0.2.3", features = ["unproven"] }

--- a/src/cdev_pin.rs
+++ b/src/cdev_pin.rs
@@ -1,4 +1,4 @@
-use core::ops;
+//! Linux CDev pin type
 
 /// Newtype around [`gpio_cdev::LineHandle`] that implements the `embedded-hal` traits
 ///
@@ -43,7 +43,7 @@ impl hal::digital::v2::InputPin for CdevPin {
     }
 }
 
-impl ops::Deref for CdevPin {
+impl core::ops::Deref for CdevPin {
     type Target = gpio_cdev::LineHandle;
 
     fn deref(&self) -> &Self::Target {
@@ -51,7 +51,7 @@ impl ops::Deref for CdevPin {
     }
 }
 
-impl ops::DerefMut for CdevPin {
+impl core::ops::DerefMut for CdevPin {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,15 +15,19 @@
 extern crate cast;
 extern crate core;
 extern crate embedded_hal as hal;
-#[cfg(feature = "gpio_cdev")]
-pub extern crate gpio_cdev;
 pub extern crate i2cdev;
-pub extern crate nb;
-pub extern crate serial_core;
-pub extern crate serial_unix;
 pub extern crate spidev;
+pub extern crate serial_unix;
+pub extern crate serial_core;
+pub extern crate nb;
+
+
 #[cfg(feature = "gpio_sysfs")]
 pub extern crate sysfs_gpio;
+
+#[cfg(feature = "gpio_cdev")]
+pub extern crate gpio_cdev;
+
 
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -37,18 +41,23 @@ use spidev::SpidevTransfer;
 
 mod serial;
 
-#[cfg(feature = "gpio_cdev")]
-/// Cdev Pin wrapper module
-mod cdev_pin;
+pub use serial::Serial;
+
 #[cfg(feature = "gpio_sysfs")]
 /// Sysfs Pin wrapper module
 mod sysfs_pin;
 
 #[cfg(feature = "gpio_cdev")]
+/// Cdev Pin wrapper module
+mod cdev_pin;
+
+#[cfg(feature = "gpio_cdev")]
+/// Cdev pin re-export
 pub use cdev_pin::CdevPin;
-pub use serial::Serial;
 #[cfg(feature = "gpio_sysfs")]
+/// Sysfs pin re-export
 pub use sysfs_pin::SysfsPin;
+
 
 /// Empty struct that provides delay functionality on top of `thread::sleep`
 pub struct Delay;
@@ -106,6 +115,22 @@ impl hal::blocking::delay::DelayMs<u64> for Delay {
         thread::sleep(Duration::from_millis(n))
     }
 }
+
+
+#[cfg(all(feature = "gpio_sysfs", feature = "gpio_cdev"))]
+/// Re-export of `sysfs_pin::SysfsPin` when both pin types are enabled
+/// This exists to maintain backwards compatibility with existing users
+pub type Pin = sysfs_pin::SysfsPin;
+
+#[cfg(all(feature = "gpio_sysfs", not(feature = "gpio_cdev")))]
+/// Re-export of `sysfs_pin::SysfsPin` pin type when `gpio_sysfs` feature is selected
+pub type Pin = sysfs_pin::SysfsPin;
+
+#[cfg(all(feature = "gpio_cdev", not(feature = "gpio_sysfs")))]
+/// Re-export of `cdev_pin::CdevPin` pin type when `gpio_cdev` feature is selected
+pub type Pin = cdev_pin::CdevPin;
+
+
 
 /// Newtype around [`i2cdev::linux::LinuxI2CDevice`] that implements the `embedded-hal` traits
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,21 +117,6 @@ impl hal::blocking::delay::DelayMs<u64> for Delay {
 }
 
 
-#[cfg(all(feature = "gpio_sysfs", feature = "gpio_cdev"))]
-/// Re-export of `sysfs_pin::SysfsPin` when both pin types are enabled
-/// This exists to maintain backwards compatibility with existing users
-pub type Pin = sysfs_pin::SysfsPin;
-
-#[cfg(all(feature = "gpio_sysfs", not(feature = "gpio_cdev")))]
-/// Re-export of `sysfs_pin::SysfsPin` pin type when `gpio_sysfs` feature is selected
-pub type Pin = sysfs_pin::SysfsPin;
-
-#[cfg(all(feature = "gpio_cdev", not(feature = "gpio_sysfs")))]
-/// Re-export of `cdev_pin::CdevPin` pin type when `gpio_cdev` feature is selected
-pub type Pin = cdev_pin::CdevPin;
-
-
-
 /// Newtype around [`i2cdev::linux::LinuxI2CDevice`] that implements the `embedded-hal` traits
 ///
 /// [`i2cdev::linux::LinuxI2CDevice`]: https://docs.rs/i2cdev/0.3.1/i2cdev/linux/struct.LinuxI2CDevice.html

--- a/src/sysfs_pin.rs
+++ b/src/sysfs_pin.rs
@@ -1,4 +1,5 @@
-use std::ops;
+//! Linux Sysfs pin type
+
 use std::path::Path;
 
 /// Newtype around [`sysfs_gpio::Pin`] that implements the `embedded-hal` traits
@@ -53,7 +54,7 @@ impl hal::digital::v2::InputPin for SysfsPin {
     }
 }
 
-impl ops::Deref for SysfsPin {
+impl core::ops::Deref for SysfsPin {
     type Target = sysfs_gpio::Pin;
 
     fn deref(&self) -> &Self::Target {
@@ -61,7 +62,7 @@ impl ops::Deref for SysfsPin {
     }
 }
 
-impl ops::DerefMut for SysfsPin {
+impl core::ops::DerefMut for SysfsPin {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }


### PR DESCRIPTION
- added both features by default
- re-export `Pin` type using type aliases
- default behaviour exports cdev for backwards compatibility
- package builds with any combination of gpio features