### PR TITLE
Update the spidev documentation links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,13 +200,13 @@ impl ops::DerefMut for I2cdev {
 
 /// Newtype around [`spidev::Spidev`] that implements the `embedded-hal` traits
 ///
-/// [`spidev::Spidev`]: https://docs.rs/spidev/0.3.0/spidev/struct.Spidev.html
+/// [`spidev::Spidev`]: https://docs.rs/spidev/0.4.0/spidev/struct.Spidev.html
 pub struct Spidev(pub spidev::Spidev);
 
 impl Spidev {
     /// See [`spidev::Spidev::open`][0] for details.
     ///
-    /// [0]: https://docs.rs/spidev/0.3.0/spidev/struct.Spidev.html#method.open
+    /// [0]: https://docs.rs/spidev/0.4.0/spidev/struct.Spidev.html#method.open
     pub fn open<P>(path: P) -> io::Result<Self>
     where
         P: AsRef<Path>,


### PR DESCRIPTION
There were two links in the doc comments (of the `Spidev` struct and the `Spidev::open()` method) that guided to the documentation of the old (0.3.0) version of the spidev crate. This patch updates those links to direct to the new version (0.4.0, the same as _this_ crate depends on).