### PR TITLE
Adapt to embedded-hal-1.0.0-alpha.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ gpio_cdev = ["gpio-cdev"]
 default = [ "gpio_cdev", "gpio_sysfs" ]
 
 [dependencies]
-embedded-hal = { version = "0.2.3", features = ["unproven"] }
+embedded-hal = "=1.0.0-alpha.1"
 gpio-cdev = { version = "0.3", optional = true }
 sysfs_gpio = { version = "0.5", optional = true }
 
@@ -24,7 +24,6 @@ nb = "0.1.1"
 serial-core = "0.4.0"
 serial-unix = "0.4.0"
 spidev = "0.4"
-void = "1"
 
 [dev-dependencies]
 openpty = "0.1.0"

--- a/src/cdev_pin.rs
+++ b/src/cdev_pin.rs
@@ -15,22 +15,22 @@ impl CdevPin {
     }
 }
 
-impl hal::digital::v2::OutputPin for CdevPin {
+impl hal::digital::OutputPin for CdevPin {
     type Error = gpio_cdev::errors::Error;
 
-    fn set_low(&mut self) -> Result<(), Self::Error> {
+    fn try_set_low(&mut self) -> Result<(), Self::Error> {
         self.0.set_value(0)
     }
 
-    fn set_high(&mut self) -> Result<(), Self::Error> {
+    fn try_set_high(&mut self) -> Result<(), Self::Error> {
         self.0.set_value(1)
     }
 }
 
-impl hal::digital::v2::InputPin for CdevPin {
+impl hal::digital::InputPin for CdevPin {
     type Error = gpio_cdev::errors::Error;
 
-    fn is_high(&self) -> Result<bool, Self::Error> {
+    fn try_is_high(&self) -> Result<bool, Self::Error> {
         if !self.1 {
             self.0.get_value().map(|val| val != 0)
         } else {
@@ -38,8 +38,8 @@ impl hal::digital::v2::InputPin for CdevPin {
         }
     }
 
-    fn is_low(&self) -> Result<bool, Self::Error> {
-        self.is_high().map(|val| !val)
+    fn try_is_low(&self) -> Result<bool, Self::Error> {
+        self.try_is_high().map(|val| !val)
     }
 }
 

--- a/src/sysfs_pin.rs
+++ b/src/sysfs_pin.rs
@@ -26,22 +26,22 @@ impl SysfsPin {
     }
 }
 
-impl hal::digital::v2::OutputPin for SysfsPin {
+impl hal::digital::OutputPin for SysfsPin {
     type Error = sysfs_gpio::Error;
 
-    fn set_low(&mut self) -> Result<(), Self::Error> {
+    fn try_set_low(&mut self) -> Result<(), Self::Error> {
         self.0.set_value(0)
     }
 
-    fn set_high(&mut self) -> Result<(), Self::Error> {
+    fn try_set_high(&mut self) -> Result<(), Self::Error> {
         self.0.set_value(1)
     }
 }
 
-impl hal::digital::v2::InputPin for SysfsPin {
+impl hal::digital::InputPin for SysfsPin {
     type Error = sysfs_gpio::Error;
 
-    fn is_high(&self) -> Result<bool, Self::Error> {
+    fn try_is_high(&self) -> Result<bool, Self::Error> {
         if !self.0.get_active_low()? {
             self.0.get_value().map(|val| val != 0)
         } else {
@@ -49,8 +49,8 @@ impl hal::digital::v2::InputPin for SysfsPin {
         }
     }
 
-    fn is_low(&self) -> Result<bool, Self::Error> {
-        self.is_high().map(|val| !val)
+    fn try_is_low(&self) -> Result<bool, Self::Error> {
+        self.try_is_high().map(|val| !val)
     }
 }
 


### PR DESCRIPTION
I adapted this to the `embedded-hal-1.0.0-alpha.1` release.
As part of it I also replaced `void` with `core::convert::Infallible`.

(blocked on https://github.com/rust-embedded/embedded-hal/issues/177)