### PR TITLE
Implement transactional I2C interface and add example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ gpio_cdev = ["gpio-cdev"]
 default = [ "gpio_cdev", "gpio_sysfs" ]
 
 [dependencies]
-embedded-hal = "=1.0.0-alpha.3"
+embedded-hal = "=1.0.0-alpha.4"
 gpio-cdev = { version = "0.3", optional = true }
 sysfs_gpio = { version = "0.5", optional = true }
 

--- a/examples/transactional-i2c.rs
+++ b/examples/transactional-i2c.rs
@@ -1,0 +1,35 @@
+extern crate embedded_hal;
+extern crate linux_embedded_hal;
+use embedded_hal::blocking::i2c::{Operation as I2cOperation, Transactional};
+use linux_embedded_hal::I2cdev;
+
+const ADDR: u8 = 0x12;
+
+struct Driver<I2C> {
+    i2c: I2C,
+}
+
+impl<I2C> Driver<I2C>
+where
+    I2C: Transactional,
+{
+    pub fn new(i2c: I2C) -> Self {
+        Driver { i2c }
+    }
+
+    fn read_something(&mut self) -> Result<u8, I2C::Error> {
+        let mut read_buffer = [0];
+        let mut ops = [
+            I2cOperation::Write(&[0xAB]),
+            I2cOperation::Read(&mut read_buffer),
+        ];
+        self.i2c.try_exec(ADDR, &mut ops).and(Ok(read_buffer[0]))
+    }
+}
+
+fn main() {
+    let dev = I2cdev::new("/dev/i2c-1").unwrap();
+    let mut driver = Driver::new(dev);
+    let value = driver.read_something().unwrap();
+    println!("Read value: {}", value);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ use std::time::Duration;
 use std::{ops, thread};
 
 use cast::{u32, u64};
+use hal::blocking::i2c::Operation as I2cOperation;
 use i2cdev::core::{I2CDevice, I2CMessage, I2CTransfer};
 use i2cdev::linux::LinuxI2CMessage;
 use spidev::SpidevTransfer;
@@ -203,6 +204,26 @@ impl hal::blocking::i2c::WriteRead for I2cdev {
     ) -> Result<(), Self::Error> {
         self.set_address(address)?;
         let mut messages = [LinuxI2CMessage::write(bytes), LinuxI2CMessage::read(buffer)];
+        self.inner.transfer(&mut messages).map(drop)
+    }
+}
+
+impl hal::blocking::i2c::Transactional for I2cdev {
+    type Error = i2cdev::linux::LinuxI2CError;
+
+    fn try_exec(&mut self, address: u8, operations: &mut [I2cOperation]) -> Result<(), Self::Error>
+    {
+        // Map operations from generic to linux objects
+        let mut messages: Vec<_> = operations
+            .as_mut()
+            .iter_mut()
+            .map(|a| match a {
+                I2cOperation::Write(w) => LinuxI2CMessage::write(w),
+                I2cOperation::Read(r) => LinuxI2CMessage::read(r),
+            })
+            .collect();
+
+        self.set_address(address)?;
         self.inner.transfer(&mut messages).map(drop)
     }
 }


### PR DESCRIPTION
I implemented the transactional I2C interface from https://github.com/rust-embedded/embedded-hal/pull/223 and added an example with a driver which does a combined Write/Read transaction.
This is based on previous work from #33 by @ryankurte, https://github.com/rust-embedded/rust-i2cdev/pull/51 and is similar to #35.