### PR TITLE
Update for v1.0.0-alpha.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["Linux", "hal"]
 license = "MIT OR Apache-2.0"
 name = "linux-embedded-hal"
 repository = "https://github.com/japaric/linux-embedded-hal"
-version = "0.3.0"
+version = "1.0.0-alpha.0"
 
 [features]
 gpio_sysfs = ["sysfs_gpio"]
@@ -15,7 +15,7 @@ gpio_cdev = ["gpio-cdev"]
 default = [ "gpio_cdev", "gpio_sysfs" ]
 
 [dependencies]
-embedded-hal = { version = "0.2.3", features = ["unproven"] }
+embedded-hal = { version = "=1.0.0-alpha.2", features = ["unproven"] }
 gpio-cdev = { version = "0.3", optional = true }
 sysfs_gpio = { version = "0.5", optional = true }
 
@@ -33,3 +33,4 @@ openpty = "0.1.0"
 # we don't need the `Error` implementation
 default-features = false
 version = "0.2.2"
+

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This project is developed and maintained by the [Embedded Linux team][team].
 
 ## [Documentation](https://docs.rs/linux-embedded-hal)
 
+Note that current releases track the unstable ['embedded-hal'] `v1.0.0-alpha`.
+For bugfixes or backports please open PRs against the `v0.3.x` branch.
+
+
 ## GPIO character device
 
 Since Linux kernel v4.4 the use of sysfs GPIO was deprecated and replaced by the character device GPIO.
@@ -22,10 +26,12 @@ linux-embedded-hal = { version = "0.3", features = ["gpio_cdev"] }
 
 `SysfsPin` can be still used with feature flag `gpio_sysfs`.
 
-# Minimum Supported Rust Version (MSRV)
+
+## Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile on stable Rust 1.36.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
+
 
 ## License
 
@@ -43,6 +49,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
+
 ## Code of Conduct
 
 Contribution to this crate is organized under the terms of the [Rust Code of
@@ -51,3 +58,4 @@ to intervene to uphold that code of conduct.
 
 [CoC]: CODE_OF_CONDUCT.md
 [team]: https://github.com/rust-embedded/wg/#the-embedded-linux-team
+


### PR DESCRIPTION
Update `README.md` with branch details, `Cargo.toml` with new version and `e-h` version `1.0.0-alpha.2`.

Blocked on https://github.com/rust-embedded/linux-embedded-hal/pull/48