### PR TITLE
Update gpio-cdev to 0.4.0 and add async-tokio feature

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -4,5 +4,5 @@ required_approvals = 1
 status = [
   "CI (stable, x86_64-unknown-linux-gnu)",
   "CI (stable, armv7-unknown-linux-gnueabihf)",
-  "CI (1.35.0, x86_64-unknown-linux-gnu)",
+  "CI (1.36.0, x86_64-unknown-linux-gnu)",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
         include:
           # Test MSRV
-          - rust: 1.35.0
+          - rust: 1.36.0
             TARGET: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,13 @@ edition = "2018"
 [features]
 gpio_sysfs = ["sysfs_gpio"]
 gpio_cdev = ["gpio-cdev"]
+async-tokio = ["gpio-cdev/async-tokio"]
 
 default = [ "gpio_cdev", "gpio_sysfs" ]
 
 [dependencies]
 embedded-hal = "=1.0.0-alpha.4"
-gpio-cdev = { version = "0.3", optional = true }
+gpio-cdev = { version = "0.4", optional = true }
 sysfs_gpio = { version = "0.5", optional = true }
 
 i2cdev = "0.4.3"
@@ -36,4 +37,3 @@ openpty = "0.1.0"
 # we don't need the `Error` implementation
 default-features = false
 version = "0.2.2"
-


### PR DESCRIPTION
It'd be lovely to allow streaming of chip line events asynchronously now that `gpio-cdev` supports it.