### PR TITLE
Fix active low behavior of GPIO output pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Modified `OutputPin` behavior for active-low pins to match `InputPin` behavior.
 - Set default features to build both sysfs and cdev pin types.
 - Removed `Pin` export, use `CdevPin` or `SysfsPin`.
 - Increased the Minimum Supported Rust Version to `1.36.0` due to an update of `gpio_cdev`.

--- a/src/cdev_pin.rs
+++ b/src/cdev_pin.rs
@@ -19,11 +19,19 @@ impl embedded_hal::digital::OutputPin for CdevPin {
     type Error = gpio_cdev::errors::Error;
 
     fn try_set_low(&mut self) -> Result<(), Self::Error> {
-        self.0.set_value(0)
+        if self.1 {
+            self.0.set_value(1)
+        } else {
+            self.0.set_value(0)
+        }
     }
 
     fn try_set_high(&mut self) -> Result<(), Self::Error> {
-        self.0.set_value(1)
+        if self.1 {
+            self.0.set_value(0)
+        } else {
+            self.0.set_value(1)
+        }
     }
 }
 

--- a/src/sysfs_pin.rs
+++ b/src/sysfs_pin.rs
@@ -30,11 +30,19 @@ impl embedded_hal::digital::OutputPin for SysfsPin {
     type Error = sysfs_gpio::Error;
 
     fn try_set_low(&mut self) -> Result<(), Self::Error> {
-        self.0.set_value(0)
+        if self.0.get_active_low()? {
+            self.0.set_value(1)
+        } else {
+            self.0.set_value(0)
+        }
     }
 
     fn try_set_high(&mut self) -> Result<(), Self::Error> {
-        self.0.set_value(1)
+        if self.0.get_active_low()? {
+            self.0.set_value(0)
+        } else {
+            self.0.set_value(1)
+        }
     }
 }
 


### PR DESCRIPTION
When an output pin is in active-low mode, the try_set_low and try_set_high functions currently incorrect behavior.

In keeping with the input behavior for `try_is_high` and `try_is_low`, "high" and "low" should refer to the actual output voltage. This works as expected for pins that are not in active-low mode, but if a pin is in active-low mode, then the opposite happens:

 * calling `try_set_low` sets the voltage high
 * calling `try_set_high` sets the voltage low

This bug and the fix have been verified using [this test program](https://github.com/MorganR/active-low-test).