### PR TITLE
Raise minimum dependency versions to enforce using a newer nix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,17 +21,17 @@ default = [ "gpio_cdev", "gpio_sysfs" ]
 
 [dependencies]
 embedded-hal = "=1.0.0-alpha.5"
-gpio-cdev = { version = "0.5", optional = true }
-sysfs_gpio = { version = "0.6", optional = true }
+gpio-cdev = { version = "0.5.1", optional = true }
+sysfs_gpio = { version = "0.6.1", optional = true }
 
-i2cdev = "0.5"
+i2cdev = "0.5.1"
 nb = "1"
 serial-core = "0.4.0"
 serial-unix = "0.4.0"
-spidev = "0.5"
+spidev = "0.5.1"
 
 [dev-dependencies]
-openpty = "0.1.0"
+openpty = "0.2.0"
 
 [dependencies.cast]
 # we don't need the `Error` implementation


### PR DESCRIPTION
Doing this for 0.3.x is not possible due to a raise in the MSRV.
Closes #70 