### PR TITLE
Add features for spi and i2c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added feature flag for `spi` and `i2c`
+
 ## [v0.4.0-alpha.2] - 2022-02-15
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,20 @@ edition = "2018"
 gpio_sysfs = ["sysfs_gpio"]
 gpio_cdev = ["gpio-cdev"]
 async-tokio = ["gpio-cdev/async-tokio"]
+i2c = ["i2cdev"]
+spi = ["spidev"]
 
-default = [ "gpio_cdev", "gpio_sysfs" ]
+default = [ "gpio_cdev", "gpio_sysfs", "i2c", "spi" ]
 
 [dependencies]
 embedded-hal = "=1.0.0-alpha.7"
 gpio-cdev = { version = "0.5.1", optional = true }
 sysfs_gpio = { version = "0.6.1", optional = true }
-i2cdev = "0.5.1"
+i2cdev = { version = "0.5.1", optional = true }
 nb = "1"
 serial-core = "0.4.0"
 serial-unix = "0.4.0"
-spidev = "0.5.1"
+spidev = { version = "0.5.1", optional = true }
 nix = "0.23.1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ linux-embedded-hal = { version = "0.3", features = ["gpio_cdev"] }
 
 `SysfsPin` can be still used with feature flag `gpio_sysfs`.
 
+With `default-features = false` you can enable the features `gpio_cdev`, `gpio_sysfs`, `i2c`, and `spi` as needed.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile on stable Rust 1.46.0 and up. It *might*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,12 @@
 
 #![deny(missing_docs)]
 
+#[cfg(feature = "i2c")]
 pub use i2cdev;
 pub use nb;
 pub use serial_core;
 pub use serial_unix;
+#[cfg(feature = "spi")]
 pub use spidev;
 
 #[cfg(feature = "gpio_sysfs")]
@@ -40,13 +42,17 @@ pub use cdev_pin::CdevPin;
 pub use sysfs_pin::SysfsPin;
 
 mod delay;
+#[cfg(feature = "i2c")]
 mod i2c;
 mod serial;
+#[cfg(feature = "spi")]
 mod spi;
 mod timer;
 
 pub use crate::delay::Delay;
+#[cfg(feature = "i2c")]
 pub use crate::i2c::{I2CError, I2cdev};
 pub use crate::serial::{Serial, SerialError};
+#[cfg(feature = "spi")]
 pub use crate::spi::{SPIError, Spidev};
 pub use crate::timer::{CountDown, Periodic, SysTimer};


### PR DESCRIPTION
Adds the features `i2c` and `spi` for an optional dependency on `i2cdev` and `spidev`.

Discussion in #80.
Closes #80 