### PR TITLE
serial: Replace the serial-rs crate with serialport-rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- [breaking-change] Replace serial-rs with the serialport-rs crate.
+### Changed
+- [breaking-change] Replace serial-rs with the serialport-rs crate. `Serial::open` now needs a baud-rate argument as well.
 
 ## [v0.4.0-alpha.3] - 2022-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [breaking-change] Replace serial-rs with the serialport-rs crate.
+
 ## [v0.4.0-alpha.3] - 2022-08-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,7 @@ gpio-cdev = { version = "0.5.1", optional = true }
 sysfs_gpio = { version = "0.6.1", optional = true }
 i2cdev = { version = "0.5.1", optional = true }
 nb = "1"
-serial-core = "0.4.0"
-serial-unix = "0.4.0"
+serialport = { version = "4.2.0", default-features = false }
 spidev = { version = "0.5.1", optional = true }
 nix = "0.23.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,7 @@
 #[cfg(feature = "i2c")]
 pub use i2cdev;
 pub use nb;
-pub use serial_core;
-pub use serial_unix;
+pub use serialport;
 #[cfg(feature = "spi")]
 pub use spidev;
 


### PR DESCRIPTION
Replace the unmaintained serial-rs crate with serialport-rs.
Closes #86 