### PR TITLE
Update embedded-hal to 1.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v1.0.0-rc.1] - 2023-09-06
+
 ### Changed
 - [breaking-change] Replace serial-rs with the serialport-rs crate. `Serial::open` now needs a baud-rate argument as well.
-- Updated to `embedded-hal` `1.0.0-alpha.11` release ([API changes](https://github.com/rust-embedded/embedded-hal/blob/master/embedded-hal/CHANGELOG.md#v100-alpha11---2023-07-04))
-- Updated to `spidev` `0.5.2` release([API changes](https://github.com/rust-embedded/rust-spidev/blob/master/CHANGELOG.md#052--2023-08-02))
+- Updated to `embedded-hal` `1.0.0-rc.1` release ([API changes](https://github.com/rust-embedded/embedded-hal/blob/master/embedded-hal/CHANGELOG.md#v100-rc1---2023-08-15))
+- Updated to `embedded-hal-nb` `1.0.0-rc.1` release ([API changes](https://github.com/rust-embedded/embedded-hal/blob/master/embedded-hal-nb/CHANGELOG.md#v100-rc1---2023-08-15))
+- Updated to `spidev` `0.6.0` release([API changes](https://github.com/rust-embedded/rust-spidev/blob/master/CHANGELOG.md#060--2023-08-03))
+- Updated to `i2cdev` `0.6.0` release([API changes](https://github.com/rust-embedded/rust-i2cdev/blob/master/CHANGELOG.md#v060---2023-08-03))
+- Updated to `nix` `0.26` to match `i2cdev`
 
 ### Fixed
 - Fix using SPI transfer with unequal buffer sizes (#97, #98).
@@ -138,7 +143,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/linux-embedded-hal/compare/v0.4.0-alpha.3...HEAD
+[Unreleased]: https://github.com/rust-embedded/linux-embedded-hal/compare/v1.0.0-rc.1...HEAD
+[v1.0.0-rc.1]: https://github.com/rust-embedded/linux-embedded-hal/compare/v0.4.0-alpha.3...v1.0.0-rc.1
 [v0.4.0-alpha.3]: https://github.com/rust-embedded/linux-embedded-hal/compare/v0.4.0-alpha.2...v0.4.0-alpha.3
 [v0.4.0-alpha.2]: https://github.com/rust-embedded/linux-embedded-hal/compare/v0.4.0-alpha.1...v0.4.0-alpha.2
 [v0.4.0-alpha.1]: https://github.com/rust-embedded/linux-embedded-hal/compare/v0.3.0...v0.4.0-alpha.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [v1.0.0-rc.1] - 2023-09-06
-
 ### Changed
 - [breaking-change] Replace serial-rs with the serialport-rs crate. `Serial::open` now needs a baud-rate argument as well.
 - Updated to `embedded-hal` `1.0.0-rc.1` release ([API changes](https://github.com/rust-embedded/embedded-hal/blob/master/embedded-hal/CHANGELOG.md#v100-rc1---2023-08-15))
@@ -143,8 +141,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/linux-embedded-hal/compare/v1.0.0-rc.1...HEAD
-[v1.0.0-rc.1]: https://github.com/rust-embedded/linux-embedded-hal/compare/v0.4.0-alpha.3...v1.0.0-rc.1
+[Unreleased]: https://github.com/rust-embedded/linux-embedded-hal/compare/v0.4.0-alpha.3...HEAD
 [v0.4.0-alpha.3]: https://github.com/rust-embedded/linux-embedded-hal/compare/v0.4.0-alpha.2...v0.4.0-alpha.3
 [v0.4.0-alpha.2]: https://github.com/rust-embedded/linux-embedded-hal/compare/v0.4.0-alpha.1...v0.4.0-alpha.2
 [v0.4.0-alpha.1]: https://github.com/rust-embedded/linux-embedded-hal/compare/v0.3.0...v0.4.0-alpha.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["Linux", "hal"]
 license = "MIT OR Apache-2.0"
 name = "linux-embedded-hal"
 repository = "https://github.com/rust-embedded/linux-embedded-hal"
-version = "0.4.0-alpha.3"
+version = "1.0.0-rc.1"
 edition = "2018"
 
 [features]
@@ -22,15 +22,15 @@ spi = ["spidev"]
 default = [ "gpio_cdev", "gpio_sysfs", "i2c", "spi" ]
 
 [dependencies]
-embedded-hal = "=1.0.0-alpha.11"
-embedded-hal-nb = "=1.0.0-alpha.3"
+embedded-hal = "=1.0.0-rc.1"
+embedded-hal-nb = "=1.0.0-rc.1"
 gpio-cdev = { version = "0.5.1", optional = true }
 sysfs_gpio = { version = "0.6.1", optional = true }
-i2cdev = { version = "0.5.1", optional = true }
+i2cdev = { version = "0.6.0", optional = true }
 nb = "1"
 serialport = { version = "4.2.0", default-features = false }
-spidev = { version = "0.5.2", optional = true }
-nix = "0.23.1"
+spidev = { version = "0.6.0", optional = true }
+nix = "0.26.2"
 
 [dev-dependencies]
 openpty = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["Linux", "hal"]
 license = "MIT OR Apache-2.0"
 name = "linux-embedded-hal"
 repository = "https://github.com/rust-embedded/linux-embedded-hal"
-version = "1.0.0-rc.1"
+version = "0.4.0-alpha.3"
 edition = "2018"
 
 [features]

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -138,7 +138,7 @@ impl embedded_hal::i2c::Error for I2CError {
         use nix::errno::Errno::*;
 
         let errno = match &self.err {
-            i2cdev::linux::LinuxI2CError::Nix(e) => *e,
+            i2cdev::linux::LinuxI2CError::Errno(e) => nix::Error::from_i32(*e),
             i2cdev::linux::LinuxI2CError::Io(e) => match e.raw_os_error() {
                 Some(r) => nix::Error::from_i32(r),
                 None => return ErrorKind::Other,

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -32,7 +32,7 @@ fn translate_io_errors(err: std::io::Error) -> nb::Error<SerialError> {
     }
 }
 
-impl embedded_hal::serial::ErrorType for Serial {
+impl embedded_hal_nb::serial::ErrorType for Serial {
     type Error = SerialError;
 }
 
@@ -80,10 +80,10 @@ impl fmt::Display for SerialError {
 
 impl std::error::Error for SerialError {}
 
-impl embedded_hal::serial::Error for SerialError {
+impl embedded_hal_nb::serial::Error for SerialError {
     #[allow(clippy::match_single_binding)]
-    fn kind(&self) -> embedded_hal::serial::ErrorKind {
-        use embedded_hal::serial::ErrorKind::*;
+    fn kind(&self) -> embedded_hal_nb::serial::ErrorKind {
+        use embedded_hal_nb::serial::ErrorKind::*;
         // TODO: match any errors here if we can find any that are relevant
         Other
     }
@@ -120,7 +120,7 @@ mod test {
     #[test]
     fn test_read() {
         let (mut master, mut serial) = create_pty_and_serial();
-        master.write(&[1]).expect("Write failed");
+        master.write_all(&[1]).expect("Write failed");
         assert_eq!(Ok(1), serial.read());
     }
 


### PR DESCRIPTION
I thought the crate could be bumped to 1.0.0-rc.1 as well. What do you think? 