### PR TITLE
Prepare `-alpha.4` release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - 'async-tokio,gpio_cdev,gpio_sysfs,i2c,spi'
 
         include:
-          - rust: 1.60.0 # MSRV
+          - rust: 1.65.0 # MSRV
             target: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.73.0
           components: clippy
       - run: cargo clippy --all-features -- --deny=warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Changed
-- Updated to `embedded-hal` `1.0.0-rc.3` release ([API changes](https://github.com/rust-embedded/embedded-hal/blob/master/embedded-hal/CHANGELOG.md#v100-rc3---2023-12-14))
-- Updated to `embedded-hal-nb` `1.0.0-rc.3` release ([API changes](https://github.com/rust-embedded/embedded-hal/blob/master/embedded-hal-nb/CHANGELOG.md#v100-rc3---2023-12-14))
-
-## [v0.4.0-alpha.4] - 2023-11-10
+## [v0.4.0-alpha.4] - 2024-01-03
 
 ### Changed
 - [breaking-change] Replace serial-rs with the serialport-rs crate. `Serial::open` now needs a baud-rate argument as well.
 - [breaking-change] Split `Spidev` into `SpidevDevice` and `SpidevBus`, implementing the respective `SpiDevice` and `SpiBus` traits (#100)
-- Updated to `embedded-hal` `1.0.0-rc.1` release ([API changes](https://github.com/rust-embedded/embedded-hal/blob/master/embedded-hal/CHANGELOG.md#v100-rc1---2023-08-15))
-- Updated to `embedded-hal-nb` `1.0.0-rc.1` release ([API changes](https://github.com/rust-embedded/embedded-hal/blob/master/embedded-hal-nb/CHANGELOG.md#v100-rc1---2023-08-15))
+- Updated to `embedded-hal` `1.0.0-rc.3` release ([API changes](https://github.com/rust-embedded/embedded-hal/blob/master/embedded-hal/CHANGELOG.md#v100-rc3---2023-12-14))
+- Updated to `embedded-hal-nb` `1.0.0-rc.3` release ([API changes](https://github.com/rust-embedded/embedded-hal/blob/master/embedded-hal-nb/CHANGELOG.md#v100-rc3---2023-12-14))
 - Updated to `spidev` `0.6.0` release([API changes](https://github.com/rust-embedded/rust-spidev/blob/master/CHANGELOG.md#060--2023-08-03))
 - Updated to `i2cdev` `0.6.0` release([API changes](https://github.com/rust-embedded/rust-i2cdev/blob/master/CHANGELOG.md#v060---2023-08-03))
 - Updated to `gpio_cdev` `0.6.0` release([API changes](https://github.com/rust-embedded/gpio-cdev/blob/master/CHANGELOG.md#v060--2023-09-11))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated to `embedded-hal-nb` `1.0.0-rc.1` release ([API changes](https://github.com/rust-embedded/embedded-hal/blob/master/embedded-hal-nb/CHANGELOG.md#v100-rc1---2023-08-15))
 - Updated to `spidev` `0.6.0` release([API changes](https://github.com/rust-embedded/rust-spidev/blob/master/CHANGELOG.md#060--2023-08-03))
 - Updated to `i2cdev` `0.6.0` release([API changes](https://github.com/rust-embedded/rust-i2cdev/blob/master/CHANGELOG.md#v060---2023-08-03))
-- Updated to `nix` `0.26` to match `i2cdev`
+- Updated to `gpio_cdev` `0.6.0` release([API changes](https://github.com/rust-embedded/gpio-cdev/blob/master/CHANGELOG.md#v060--2023-09-11))
+- Updated to `nix` `0.27.1`
+- MSRV is now 1.65.0.
 
 ### Fixed
 - Fix using SPI transfer with unequal buffer sizes (#97, #98).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["Linux", "hal"]
 license = "MIT OR Apache-2.0"
 name = "linux-embedded-hal"
 repository = "https://github.com/rust-embedded/linux-embedded-hal"
-version = "0.4.0-alpha.3"
+version = "0.4.0-alpha.4"
 edition = "2018"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ default = [ "gpio_cdev", "gpio_sysfs", "i2c", "spi" ]
 [dependencies]
 embedded-hal = "=1.0.0-rc.3"
 embedded-hal-nb = "=1.0.0-rc.3"
-gpio-cdev = { version = "0.5.1", optional = true }
+gpio-cdev = { version = "0.6.0", optional = true }
 sysfs_gpio = { version = "0.6.1", optional = true }
 i2cdev = { version = "0.6.0", optional = true }
 nb = "1"
 serialport = { version = "4.2.0", default-features = false }
 spidev = { version = "0.6.0", optional = true }
-nix = "0.26.2"
+nix = "0.27.1"
 
 [dev-dependencies]
 openpty = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![crates.io](https://img.shields.io/crates/d/linux-embedded-hal.svg)](https://crates.io/crates/linux-embedded-hal)
+[![crates.io](https://img.shields.io/crates/v/linux-embedded-hal.svg)](https://crates.io/crates/linux-embedded-hal)
+[![Documentation](https://docs.rs/linux-embedded-hal/badge.svg)](https://docs.rs/linux-embedded-hal)
+![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.65+-blue.svg)
+
 # `linux-embedded-hal`
 
 > Implementation of the [`embedded-hal`] traits for Linux devices

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ With `default-features = false` you can enable the features `gpio_cdev`, `gpio_s
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.60.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.65.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/src/cdev_pin.rs
+++ b/src/cdev_pin.rs
@@ -69,12 +69,10 @@ impl CdevPin {
         // Drop self to free the line before re-requesting it in a new mode.
         std::mem::drop(self);
 
+        let is_active_low = output_flags.intersects(gpio_cdev::LineRequestFlags::ACTIVE_LOW);
         CdevPin::new(line.request(
             output_flags,
-            state_to_value(
-                state,
-                output_flags.intersects(gpio_cdev::LineRequestFlags::ACTIVE_LOW),
-            ),
+            state_to_value(state, is_active_low),
             &consumer,
         )?)
     }


### PR DESCRIPTION
TODO: update branch protection rules to require 1.65.0

Fixes #103 