### PR TITLE
WIP: Implement `Wait` for `CdevPin` with `tokio` runtime.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 [features]
 gpio_sysfs = ["sysfs_gpio"]
 gpio_cdev = ["gpio-cdev"]
-async-tokio = ["gpio-cdev/async-tokio", "dep:embedded-hal-async", "tokio/time"]
+async-tokio = ["gpio-cdev/async-tokio", "dep:embedded-hal-async", "tokio/time", "tokio/rt", "gpiocdev/async_tokio"]
 i2c = ["i2cdev"]
 spi = ["spidev"]
 
@@ -26,6 +26,7 @@ embedded-hal = "1"
 embedded-hal-nb = "1"
 embedded-hal-async = { version = "1", optional = true }
 gpio-cdev = { version = "0.6.0", optional = true }
+gpiocdev = { version = "0.6.0" }
 sysfs_gpio = { version = "0.6.1", optional = true }
 i2cdev = { version = "0.6.0", optional = true }
 nb = "1"
@@ -36,8 +37,13 @@ tokio = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 openpty = "0.2.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [dependencies.cast]
 # we don't need the `Error` implementation
 default-features = false
 version = "0.3"
+
+[[example]]
+name = "gpio-wait"
+required-features = ["async-tokio"]

--- a/examples/gpio-wait.rs
+++ b/examples/gpio-wait.rs
@@ -1,0 +1,46 @@
+use std::error::Error;
+use std::time::Duration;
+
+use embedded_hal::digital::{InputPin, OutputPin, PinState};
+use embedded_hal_async::digital::Wait;
+use gpio_cdev::{Chip, LineRequestFlags};
+use linux_embedded_hal::CdevPin;
+use tokio::time::{sleep, timeout};
+
+// This example assumes that input/output pins are shorted.
+const INPUT_LINE: u32 = 4;
+const OUTPUT_LINE: u32 = 17;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let mut chip = Chip::new("/dev/gpiochip0")?;
+    let input = chip.get_line(INPUT_LINE)?;
+    let output = chip.get_line(OUTPUT_LINE)?;
+
+    let mut input_pin =
+        CdevPin::new(input.request(LineRequestFlags::INPUT, 0, "")?)?.into_input_pin()?;
+    let mut output_pin = CdevPin::new(output.request(LineRequestFlags::OUTPUT, 0, "")?)?
+        .into_output_pin(PinState::Low)?;
+
+    timeout(Duration::from_secs(10), async move {
+        let set_output = tokio::spawn(async move {
+            sleep(Duration::from_secs(5)).await;
+            println!("Setting output high.");
+            output_pin.set_high()
+        });
+
+        println!("Waiting for input to go high.");
+
+        input_pin.wait_for_high().await?;
+
+        assert!(input_pin.is_high()?);
+        println!("Input is now high.");
+
+        set_output.await??;
+
+        Ok::<_, Box<dyn Error>>(())
+    })
+    .await??;
+
+    Ok(())
+}


### PR DESCRIPTION
Depends on https://github.com/rust-embedded/linux-embedded-hal/issues/92, i.e. at the very least, we need an enum error type or completely switch to `gpiocdev`. Both are breaking changes, so a complete switch seems preferable.
