### PR TITLE
Make unused dependencies optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added async `DelayNs` implementation for `tokio`.
+- Added feature flag for `serial`.
 
 ## [v0.4.0] - 2024-01-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,19 @@ gpio_cdev = ["gpio-cdev"]
 async-tokio = ["gpio-cdev/async-tokio", "dep:embedded-hal-async", "tokio/time"]
 i2c = ["i2cdev"]
 spi = ["spidev"]
+serial = ["serialport", "embedded-hal-nb"]
 
-default = [ "gpio_cdev", "gpio_sysfs", "i2c", "spi" ]
+default = [ "gpio_cdev", "gpio_sysfs", "i2c", "spi", "serial" ]
 
 [dependencies]
 embedded-hal = "1"
-embedded-hal-nb = "1"
+embedded-hal-nb = { version = "1", optional = true }
 embedded-hal-async = { version = "1", optional = true }
 gpio-cdev = { version = "0.6.0", optional = true }
 sysfs_gpio = { version = "0.6.1", optional = true }
 i2cdev = { version = "0.6.0", optional = true }
 nb = "1"
-serialport = { version = "4.2.0", default-features = false }
+serialport = { version = "4.2.0", default-features = false, optional = true }
 spidev = { version = "0.6.0", optional = true }
 nix = "0.27.1"
 tokio = { version = "1", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 gpio_sysfs = ["sysfs_gpio"]
 gpio_cdev = ["gpio-cdev"]
 async-tokio = ["gpio-cdev/async-tokio", "dep:embedded-hal-async", "tokio/time"]
-i2c = ["i2cdev"]
+i2c = ["i2cdev", "nix"]
 spi = ["spidev"]
 serial = ["serialport", "embedded-hal-nb"]
 
@@ -32,7 +32,7 @@ i2cdev = { version = "0.6.0", optional = true }
 nb = "1"
 serialport = { version = "4.2.0", default-features = false, optional = true }
 spidev = { version = "0.6.0", optional = true }
-nix = "0.27.1"
+nix = { version = "0.27.1", optional = true }
 tokio = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 #[cfg(feature = "i2c")]
 pub use i2cdev;
 pub use nb;
+#[cfg(feature = "serial")]
 pub use serialport;
 #[cfg(feature = "spi")]
 pub use spidev;
@@ -43,6 +44,7 @@ pub use sysfs_pin::{SysfsPin, SysfsPinError};
 mod delay;
 #[cfg(feature = "i2c")]
 mod i2c;
+#[cfg(feature = "serial")]
 mod serial;
 #[cfg(feature = "spi")]
 mod spi;
@@ -51,6 +53,7 @@ mod timer;
 pub use crate::delay::Delay;
 #[cfg(feature = "i2c")]
 pub use crate::i2c::{I2CError, I2cdev};
+#[cfg(feature = "serial")]
 pub use crate::serial::{Serial, SerialError};
 #[cfg(feature = "spi")]
 pub use crate::spi::{SPIError, SpidevBus, SpidevDevice};


### PR DESCRIPTION
- I am working on some [examples](https://openbeagle.org/ayush1325/vsx-examples) for [PocketBeagle 2](https://www.beagleboard.org/boards/pocketbeagle-2), and we have decided to use Rust for it.
- Since it is a constrained device, it would be best to have minimal dependencies. To that end, I will be disabling `default-features` in most single peripheral examples.
- However, currently some dependencies are pulled even with the default features disabled, so I would prefer it if they were also behind a selectable feature instead.