### PR TITLE
Bump MSRV to 1.85.0 to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - 'async-tokio,gpio_cdev,gpio_sysfs,i2c,spi'
 
         include:
-          - rust: 1.84.0 # MSRV
+          - rust: 1.85.0 # MSRV
             target: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.84.0
+          toolchain: 1.85.0
           components: clippy
       - run: cargo clippy --all-features -- --deny=warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- MSRV is now 1.84.0.
+- MSRV is now 1.85.0.
 - Set `resolver = "3"`, which implies `resolver.incompatible-rust-versions = "fallback"`
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![crates.io](https://img.shields.io/crates/d/linux-embedded-hal.svg)](https://crates.io/crates/linux-embedded-hal)
 [![crates.io](https://img.shields.io/crates/v/linux-embedded-hal.svg)](https://crates.io/crates/linux-embedded-hal)
 [![Documentation](https://docs.rs/linux-embedded-hal/badge.svg)](https://docs.rs/linux-embedded-hal)
-![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.84+-blue.svg)
+![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.85+-blue.svg)
 
 # `linux-embedded-hal`
 
@@ -31,7 +31,7 @@ With `default-features = false` you can enable the features `gpio_cdev`, `gpio_s
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.84.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.85.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/src/sysfs_pin.rs
+++ b/src/sysfs_pin.rs
@@ -123,7 +123,7 @@ impl embedded_hal::digital::InputPin for SysfsPin {
     }
 
     fn is_low(&mut self) -> Result<bool, Self::Error> {
-        self.is_high().map(|val| !val).map_err(SysfsPinError::from)
+        self.is_high().map(|val| !val)
     }
 }
 


### PR DESCRIPTION
One indirect dependency, unescaper, set edition="2024" in a minor release (0.1.9) without declaring a MSRV. Therefore, even with `resolver.incompatible-rust-versions = "fallback"`, cargo will update the dependency and the CI build will fail because our MSRV doesn't support edition 2024.

Instead of locking unescaper at version 0.1.8, I prefer to bump our MSRV from 1.84.0 to 1.85.0: The next release will be a MSRV bump from 1.65.0 anyway, and it doesn't matter much if we jump to 1.84.0 or 1.85.0.

Also contains a trivial fix for a new clippy warning.